### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,8 +19,8 @@ setSource	KEYWORD2
 setTarget	KEYWORD2
 setDestination	KEYWORD2
 getState	KEYWORD2
-setColor  KEYWORD2
-setWaveform KEYWORD2
+setColor	KEYWORD2
+setWaveform	KEYWORD2
 getPower	KEYWORD2
 setPower	KEYWORD2
 getInfrared	KEYWORD2
@@ -32,7 +32,7 @@ flushPacket	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-LIFX_PROTOCOL_NUMBER 	LITERAL1
+LIFX_PROTOCOL_NUMBER	LITERAL1
 LIFX_GETSTATE	LITERAL1
 LIFX_SETCOLOR	LITERAL1
 LIFX_SETWAVEFORM	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords